### PR TITLE
feat: implement SSL certificate validation with custom CA support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,9 @@ TERASLICE_URL="http://localhost:5678" uv run fastapi dev
 
 # With debug logging
 LOG_LEVEL="DEBUG" TERASLICE_URL="http://teraslice.example.com" uv run fastapi dev
+
+# With custom CA certificate
+TERASLICE_URL="https://teraslice.example.com" CACERT_FILE="/path/to/ca.pem" uv run fastapi dev
 ```
 
 ### Docker Development
@@ -78,10 +81,10 @@ Environment variables:
 
 - `TERASLICE_URL`: Base URL for Teraslice API (required)
 - `LOG_LEVEL`: Logging level (default: INFO)
+- `CACERT_FILE`: Path to custom CA certificate file for SSL verification (optional)
 
 ### Known Limitations
 
 - Assumes Kafka connectors are named beginning with "kafka"
 - Special handling for connectors/topics containing "incoming"
 - Hard-coded job size limit of 500 for API calls
-- SSL verification disabled for Teraslice API calls

--- a/app/main.py
+++ b/app/main.py
@@ -54,10 +54,10 @@ async def get_jobs(size: None | int = 500, active: None | str = 'true', ex: None
         r = httpx.get(f'{url}/jobs', params=params, verify=verify_ssl)
         r.raise_for_status()  # Raise exception for HTTP errors
     except httpx.SSLError as e:
-        logger.error(f"SSL certificate verification failed: {e}")
+        logger.error(f"SSL certificate verification failed when connecting to {url}: {e}")
         raise
     except httpx.HTTPError as e:
-        logger.error(f"HTTP error occurred: {e}")
+        logger.error(f"HTTP error occurred when connecting to {url}: {e}")
         raise
 
     return r.json()


### PR DESCRIPTION
This PR implements SSL certificate validation for the Teraslice API connections with support for custom CA certificates.

## Changes
- Enable SSL certificate validation by default by removing verify=False
- Add CACERT_FILE environment variable for custom CA certificates
- Add proper error handling for SSL and HTTP errors
- Update documentation to reflect new configuration option
- Remove SSL verification limitation from known limitations

Fixes #4

Generated with [Claude Code](https://claude.ai/code)