### PR TITLE
Use GitHub release tag as single source of app version

### DIFF
--- a/.github/workflows/publish-tag.yaml
+++ b/.github/workflows/publish-tag.yaml
@@ -35,6 +35,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
+      - name: Set version from tag
+        id: ver
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -50,6 +54,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_VERSION=${{ steps.ver.outputs.version }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,13 @@ COPY --from=python-builder /backend/app /backend/app
 # Copy built frontend assets from frontend-builder
 COPY --from=frontend-builder /app/frontend/dist /frontend/dist
 
-# Copy pyproject.toml so the app can read its version at runtime
+# Copy pyproject.toml so the app can read its version at runtime (dev-parity
+# fallback; the release tag drives the version via APP_VERSION below)
 COPY --from=python-builder /backend/pyproject.toml /backend/pyproject.toml
+
+# Bake the app version (from the GitHub release tag) into the image
+ARG APP_VERSION
+ENV APP_VERSION=$APP_VERSION
 
 WORKDIR /backend
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -173,11 +173,17 @@ async def get_pipeline_graph():
         raise e
 
 def _read_app_version() -> str:
-    """Read the project version from pyproject.toml (the single source of truth).
+    """Determine the application version.
 
-    The path is resolved relative to this file so it does not depend on the
-    process working directory.
+    The GitHub release tag is the single source of truth: in built images the
+    version is injected via the ``APP_VERSION`` environment variable (set from
+    the release tag at Docker build time). For local development we fall back to
+    reading ``pyproject.toml`` relative to this file.
     """
+    env_version = os.environ.get("APP_VERSION")
+    if env_version:
+        return env_version
+
     pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
     try:
         with open(pyproject_path, "rb") as f:


### PR DESCRIPTION
Make the release tag the one source of truth for the app version, replacing three independently-maintained numbers.

- main.py: _read_app_version() prefers APP_VERSION env var, falls back to pyproject.toml for local dev
- Dockerfile: accept APP_VERSION build arg and bake it into the image
- publish-tag.yaml: derive version from release tag (strip leading v) and pass as a Docker build arg