### PR TITLE
  Extract GraphView interface from GraphFilters

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -13,7 +13,8 @@
       "Bash(gh issue list *)",
       "Bash(gh issue view *)",
       "Bash(swift --version)",
-      "Bash(xcodebuild -version)"
+      "Bash(xcodebuild -version)",
+      "Bash(npx vitest *)"
     ],
     "deny": []
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,12 @@ code in this repository.
 * When you are done editing files and before changes are committed you should:
   * Always run backend Python tests
     * `cd backend && uv add --group test pytest pytest-asyncio && uv run pytest && cd -`
+  * Always run frontend tests
+    * `cd frontend && npm install && npm test && cd -`
   * Always do a test build of the frontend
     * `cd frontend && npm install && npm run build && cd -`
+    * `npm run build` runs `tsc --noEmit` before `vite build`, so this also
+      typechecks. `npm run typecheck` runs that step alone.
   * Fix any errors or failures you encounter.
 
 ## Project Overview
@@ -79,11 +83,18 @@ cd frontend && npm install
 # Development server with HMR (runs on http://localhost:5173)
 cd frontend && npm run dev
 
-# Production build
+# Typecheck only
+cd frontend && npm run typecheck
+
+# Production build (typechecks first)
 cd frontend && npm run build
 
 # Preview production build
 cd frontend && npm run preview
+
+# Unit tests (Vitest)
+cd frontend && npm test
+cd frontend && npm run test:watch
 ```
 
 During development, the frontend proxies to the backend so the backend must also

--- a/TODO/002-add-mermaid-view.md
+++ b/TODO/002-add-mermaid-view.md
@@ -1,12 +1,17 @@
 # TODO: Add an Alternative 2D View (Mermaid.js / Cytoscape.js)
 
 Feasibility assessment for adding a 2D pipeline view alongside the existing
-3D force-directed graph. **Status: assessment only — no code has been written.**
+3D force-directed graph.
+
+**Status: Phase 1 done, Phases 0 and 2–5 not started.** The `GraphView`
+refactor that this depended on has landed
+([002a](./002a-refactor-GraphFilters.md)); no 2D renderer code has been written,
+and the Mermaid-vs-Cytoscape decision is still open.
 
 The headline finding is that this is very feasible: the backend needs no changes
-at all, and the frontend already contains the seam a second view would plug
-into. The bulk of the real work is not rendering — it is *reduction*, because
-some pipelines run to ~250 edges (jobs) and a 250-edge 2D layout is unreadable
+at all, and the frontend now has an explicit interface a second view plugs into.
+The bulk of the real work is not rendering — it is *reduction*, because some
+pipelines run to ~250 edges (jobs) and a 250-edge 2D layout is unreadable
 without it.
 
 ---
@@ -16,7 +21,7 @@ without it.
 | Area | Verdict |
 | --- | --- |
 | Backend / API changes | None required |
-| Frontend architecture | Already ~80% ready; one modest refactor needed (split out into [002a](./002a-refactor-GraphFilters.md)) |
+| Frontend architecture | Ready — the `GraphView` refactor ([002a](./002a-refactor-GraphFilters.md)) is ✅ **done** |
 | Mermaid.js fit | Good for *export/share*, awkward for *interactivity* |
 | Cytoscape.js fit | Better for a fully interactive 2D view |
 | Scale (250 edges) | Renders, but needs reduction strategies to be useful |
@@ -57,20 +62,34 @@ exists; we are not inventing an abstraction.
 
 ---
 
-## 🔧 The One Real Refactor
+## ✅ The One Real Refactor — Done
 
-`GraphFilters` is only *partly* decoupled from the 3D renderer — it holds the
-`ForceGraph3D` instance directly and its highlight mode traverses the Three.js
-scene. A second view needs it to talk to an interface instead.
+`GraphFilters` used to be only *partly* decoupled from the 3D renderer — it
+held the `ForceGraph3D` instance directly and its highlight mode traversed the
+Three.js scene. A second view needed it to talk to an interface instead.
 
-**This has been carved out into its own plan:
-[002a-refactor-GraphFilters.md](./002a-refactor-GraphFilters.md).** It extracts
-a `GraphView` interface (`loadData / updateData / setVisibleData / highlight /
-clearHighlights`) implemented by `GraphRenderer`, with scope contained to
-`GraphFilters.ts`, `GraphRenderer.ts`, `main.ts`, and one new file.
+**This is complete** — see
+[002a-refactor-GraphFilters.md](./002a-refactor-GraphFilters.md). A `GraphView`
+interface (`loadData / updateData / setVisibleData / highlight /
+clearHighlights`) now lives in `frontend/src/graph/GraphView.ts` and is
+implemented by `GraphRenderer`. `GraphFilters` imports nothing from `three` or
+`3d-force-graph`.
 
-It is a prerequisite for a 2D view but stands on its own, and can land
-independently of any decision below.
+**What this means for a 2D view:** implement `GraphView` and hand the instance
+to `graphFilters.setView()`. The "a link is included when both endpoints are"
+rule lives inside each implementation's `highlight()`, derived from the node-id
+set it is given — so a 2D view expresses it however it likes (a CSS class, a
+Cytoscape class) without re-deriving the filter semantics. Note that
+`GuiControls` still takes the concrete `GraphRenderer`, so a view *toggle*
+(Phase 2) will need to deal with that.
+
+Two useful side effects for the work below:
+
+- `computeFilter()` now has unit test coverage (Vitest, `npm test` in
+  `frontend/`), so the reduction strategies in
+  [The 250-Edge Problem](#-the-250-edge-problem) can be built against a
+  pinned-down filter contract.
+- `npm run build` now typechecks (`tsc --noEmit && vite build`).
 
 ---
 
@@ -178,14 +197,14 @@ we go the Mermaid route.
       `_process_jobs_to_graph()`. Small, and required for stable Mermaid text
       output. Backend tests already cover this function
       (`backend/tests/unit/test_pipeline_graph_processing.py`).
-- [ ] **Phase 1 — Extract a `GraphView` interface.** Decouple `GraphFilters`
-      from `ForceGraph3D`; make `GraphRenderer` the first implementation.
-      *Small/medium.* Planned separately in
-      [002a-refactor-GraphFilters.md](./002a-refactor-GraphFilters.md) —
-      independently useful, so it need not wait on the Mermaid/Cytoscape
-      decision.
+- [x] **Phase 1 — Extract a `GraphView` interface.** ✅ **Done.** `GraphFilters`
+      is decoupled from `ForceGraph3D` and `GraphRenderer` is the first
+      implementation. See
+      [002a-refactor-GraphFilters.md](./002a-refactor-GraphFilters.md).
 - [ ] **Phase 2 — Add a view toggle.** URL hash (`#/2d`) or a `lil-gui`
-      control in `GuiControls`. *Small.*
+      control in `GuiControls`. *Small.* Note `GuiControls` takes the concrete
+      `GraphRenderer`, so this phase decides how 3D-specific settings behave
+      when a non-3D view is active.
 - [ ] **Phase 3 — Build the 2D renderer.** Data → diagram, render, pan/zoom,
       rebind click/hover for edges. *Medium.* Decide Mermaid vs Cytoscape
       first (see recommendation above).
@@ -216,10 +235,16 @@ we go the Mermaid route.
 - [backend/app/main.py](../backend/app/main.py) — `_process_jobs_to_graph()`,
   `/api/pipeline_graph`
 - [backend/app/lib/ts.py](../backend/app/lib/ts.py) — `JobInfo`, `StorageNode`
+- [frontend/src/graph/GraphView.ts](../frontend/src/graph/GraphView.ts) —
+  the interface a 2D view must implement
 - [frontend/src/graph/GraphFilters.ts](../frontend/src/graph/GraphFilters.ts) —
   `computeFilter()`, the shared filter seam
+- [frontend/src/graph/GraphFilters.test.ts](../frontend/src/graph/GraphFilters.test.ts) —
+  filter-semantics coverage, incl. a `FakeGraphView` worth copying for a 2D view
 - [frontend/src/graph/GraphRenderer.ts](../frontend/src/graph/GraphRenderer.ts) —
-  the 3D view to be abstracted behind `GraphView`
+  the 3D `GraphView` implementation
+- [frontend/src/graph/graphUtils.ts](../frontend/src/graph/graphUtils.ts) —
+  `endpointId()`, for resolving `string | GraphNode` link endpoints
 - [frontend/src/graph/GraphColors.ts](../frontend/src/graph/GraphColors.ts) —
   palette to reuse in 2D
 - [frontend/src/controls/JobsTable.ts](../frontend/src/controls/JobsTable.ts) —

--- a/TODO/002-add-mermaid-view.md
+++ b/TODO/002-add-mermaid-view.md
@@ -1,0 +1,227 @@
+# TODO: Add an Alternative 2D View (Mermaid.js / Cytoscape.js)
+
+Feasibility assessment for adding a 2D pipeline view alongside the existing
+3D force-directed graph. **Status: assessment only — no code has been written.**
+
+The headline finding is that this is very feasible: the backend needs no changes
+at all, and the frontend already contains the seam a second view would plug
+into. The bulk of the real work is not rendering — it is *reduction*, because
+some pipelines run to ~250 edges (jobs) and a 250-edge 2D layout is unreadable
+without it.
+
+---
+
+## 🎯 Summary
+
+| Area | Verdict |
+| --- | --- |
+| Backend / API changes | None required |
+| Frontend architecture | Already ~80% ready; one modest refactor needed (split out into [002a](./002a-refactor-GraphFilters.md)) |
+| Mermaid.js fit | Good for *export/share*, awkward for *interactivity* |
+| Cytoscape.js fit | Better for a fully interactive 2D view |
+| Scale (250 edges) | Renders, but needs reduction strategies to be useful |
+
+---
+
+## ✅ What Already Works In Our Favor
+
+### The API is view-agnostic
+
+`/api/pipeline_graph` ([backend/app/main.py](../backend/app/main.py), `_process_jobs_to_graph`)
+already emits a plain `{nodes, links}` structure:
+
+- Node `id` is `connection:topic|index`, plus a `connector_type`
+  (`KAFKA`/`ES`/`FILE`/`S3`/`DATA_GENERATOR`/`NOOP`/`STDOUT`/`OTHER`).
+- Each link carries `job_id`, `name`, `url`, `workers`, `status`, and
+  optionally `grafana_url`.
+
+That converts to Mermaid `flowchart` text mechanically. **No backend work.**
+
+### The frontend already has a second, non-3D consumer
+
+`GraphFilters.computeFilter()`
+([frontend/src/graph/GraphFilters.ts](../frontend/src/graph/GraphFilters.ts))
+is explicitly documented as the single source of truth shared by the 3D graph
+*and* the jobs table, and it exposes an `onFilterChange()` subscription.
+`JobsTable` is already a consumer that has nothing to do with Three.js.
+
+A 2D view is simply a **third consumer of the same pattern**. The precedent
+exists; we are not inventing an abstraction.
+
+### Styling maps over cleanly
+
+`GraphColors.ts` gives per-connector-type colors and per-status link colors.
+`GraphRenderer` scales link width from worker count
+(`((workers - 1) / 199) * 19 + 1`). Both translate directly to Mermaid
+`classDef` / `linkStyle` or to Cytoscape style selectors.
+
+---
+
+## 🔧 The One Real Refactor
+
+`GraphFilters` is only *partly* decoupled from the 3D renderer — it holds the
+`ForceGraph3D` instance directly and its highlight mode traverses the Three.js
+scene. A second view needs it to talk to an interface instead.
+
+**This has been carved out into its own plan:
+[002a-refactor-GraphFilters.md](./002a-refactor-GraphFilters.md).** It extracts
+a `GraphView` interface (`loadData / updateData / setVisibleData / highlight /
+clearHighlights`) implemented by `GraphRenderer`, with scope contained to
+`GraphFilters.ts`, `GraphRenderer.ts`, `main.ts`, and one new file.
+
+It is a prerequisite for a 2D view but stands on its own, and can land
+independently of any decision below.
+
+---
+
+## ⚠️ Where Mermaid Specifically Fights Us
+
+### Jobs are edges, not nodes — this is the significant mismatch
+
+In our data model every interesting attribute (job name, worker count, status,
+Teraslice URL, Grafana URL) lives on the **link**. Mermaid's native `click`
+directive applies to **nodes only**.
+
+So `EdgePopover` and click-to-open-Teraslice would require post-processing the
+rendered SVG to reattach handlers to edge paths. Mermaid emits per-edge path
+elements and recent versions added edge-id syntax, so it is doable — but it is
+fiddly and sensitive to Mermaid version changes.
+
+### Smaller Mermaid frictions (all solvable)
+
+- **Node ids.** `kafka_cluster1:topic1` is not a valid Mermaid id. Emit
+  synthetic `n0`, `n1`, … ids with quoted labels.
+- **Config limits.** At 250 edges we need to raise `maxEdges` and
+  `maxTextSize`.
+- **No pan/zoom** out of the box — add `svg-pan-zoom` or equivalent.
+- **Bundle size** is ~1MB+. Lazy `import()` it so the 3D view is not penalized.
+- **Direction.** `LR` is the natural orientation for a source → sink pipeline.
+
+### Mermaid's genuine advantage
+
+The output is **text**. It is copy-pasteable into GitHub, docs, and Slack, and
+renders natively in a lot of places. That is real value and it is cheap to
+ship.
+
+---
+
+## 🔀 Alternative: Cytoscape.js
+
+If we want a *fully interactive* 2D view, Cytoscape.js with a dagre or ELK
+layout is the better technical fit:
+
+- Real edge click/hover handlers — no SVG post-processing.
+- Per-edge styling (status color, worker-count width) natively.
+- Handles 250 edges comfortably.
+- Supports incremental updates, which would mesh with the existing in-place
+  refresh logic in `GraphRenderer.updateData()` /
+  `updatePropertiesInPlace()`.
+
+Other options considered: `@viz-js/viz` (Graphviz WASM) has excellent DAG
+layout quality but the same SVG-post-processing problem as Mermaid;
+`elkjs` + custom SVG is more work than it is worth here.
+
+**Recommendation:** do both, if we do more than one — Cytoscape.js as the
+interactive 2D view, Mermaid as an "export diagram" feature. They serve
+different purposes and the Mermaid text generator is a small, standalone,
+easily-tested function either way.
+
+---
+
+## 📉 The 250-Edge Problem
+
+This is where the actual design effort goes. Ranked by value-to-effort:
+
+1. **Connected-component split.** Our pipelines are almost certainly several
+   disconnected DAGs. Compute components client-side and render one at a time
+   with a picker. Cheapest change, biggest readability win.
+2. **Reuse the existing filter.** `computeFilter()` already does reduction.
+   The 2D view can default to a filtered subgraph rather than rendering
+   everything.
+3. **Focus / neighborhood mode.** Pick a node, BFS out 1–3 hops. Especially
+   natural for Mermaid, since regenerating the diagram text is cheap.
+4. **Group by connection.** Node ids are `connection:name`, so a `subgraph`
+   per connection comes essentially free — plus a collapsed mode where each
+   connection is a single node with aggregated edge counts.
+5. **Collapse `routed_sender` fan-outs.** `JobInfo.process_destination_nodes()`
+   ([backend/app/lib/ts.py](../backend/app/lib/ts.py)) emits one destination per
+   routing key, so a single job can produce many near-identical edges
+   (`index-a`, `index-b`, …). Collapsing these to `index-*  (×N)` could cut
+   edge count substantially on the worst pipelines. The `-{suffix}` pattern is
+   detectable client-side.
+6. **Status filter** (running/failing only) and a **workers threshold**.
+
+---
+
+## 🐛 One Concrete Gotcha To Fix First
+
+`_process_jobs_to_graph()` in [backend/app/main.py](../backend/app/main.py)
+returns:
+
+```python
+'nodes': list(set(nodes)),
+```
+
+Python string hashing is seeded per-process, so **node ordering varies between
+server restarts**. That is invisible in a force-directed 3D layout, but Mermaid
+output is *text* — the same pipeline would produce differently-ordered diagram
+source (and potentially a different dagre layout) across restarts.
+
+Sorting there would make exported diagrams stable and diffable. Worth doing if
+we go the Mermaid route.
+
+---
+
+## 📋 Rough Implementation Plan
+
+- [ ] **Phase 0 — Stabilize node ordering.** Sort the deduplicated node list in
+      `_process_jobs_to_graph()`. Small, and required for stable Mermaid text
+      output. Backend tests already cover this function
+      (`backend/tests/unit/test_pipeline_graph_processing.py`).
+- [ ] **Phase 1 — Extract a `GraphView` interface.** Decouple `GraphFilters`
+      from `ForceGraph3D`; make `GraphRenderer` the first implementation.
+      *Small/medium.* Planned separately in
+      [002a-refactor-GraphFilters.md](./002a-refactor-GraphFilters.md) —
+      independently useful, so it need not wait on the Mermaid/Cytoscape
+      decision.
+- [ ] **Phase 2 — Add a view toggle.** URL hash (`#/2d`) or a `lil-gui`
+      control in `GuiControls`. *Small.*
+- [ ] **Phase 3 — Build the 2D renderer.** Data → diagram, render, pan/zoom,
+      rebind click/hover for edges. *Medium.* Decide Mermaid vs Cytoscape
+      first (see recommendation above).
+- [ ] **Phase 4 — Reduction controls.** Component picker, focus depth,
+      connection grouping, fan-out collapsing. *Medium — and this is the bulk
+      of the real design work.*
+- [ ] **Phase 5 — Optional: Mermaid export.** "Copy diagram source" button,
+      independent of whichever library drives the interactive view.
+
+---
+
+## 🚧 Open Questions
+
+- Mermaid or Cytoscape for the interactive 2D view — or Cytoscape for
+  interaction plus Mermaid purely as an export format?
+- Should the 2D view share the 3D view's search/filter state, or maintain its
+  own? (Sharing is the cheaper and more consistent option.)
+- Does the 2D view need auto-refresh, or is it a static snapshot? Auto-refresh
+  with re-layout on every tick will be visually jarring in 2D in a way it is
+  not in 3D.
+- What is the actual connected-component count in a real 250-edge deployment?
+  That number determines how much reduction work is genuinely needed.
+
+---
+
+## 📚 Key Files
+
+- [backend/app/main.py](../backend/app/main.py) — `_process_jobs_to_graph()`,
+  `/api/pipeline_graph`
+- [backend/app/lib/ts.py](../backend/app/lib/ts.py) — `JobInfo`, `StorageNode`
+- [frontend/src/graph/GraphFilters.ts](../frontend/src/graph/GraphFilters.ts) —
+  `computeFilter()`, the shared filter seam
+- [frontend/src/graph/GraphRenderer.ts](../frontend/src/graph/GraphRenderer.ts) —
+  the 3D view to be abstracted behind `GraphView`
+- [frontend/src/graph/GraphColors.ts](../frontend/src/graph/GraphColors.ts) —
+  palette to reuse in 2D
+- [frontend/src/controls/JobsTable.ts](../frontend/src/controls/JobsTable.ts) —
+  existing precedent for a non-3D consumer of filter state
+- [frontend/src/main.ts](../frontend/src/main.ts) — wiring / view toggle point

--- a/TODO/002a-refactor-GraphFilters.md
+++ b/TODO/002a-refactor-GraphFilters.md
@@ -246,3 +246,68 @@ to filter semantics.
 
 Estimate: small/medium. Mostly moving code, one method with real thought in it
 (`setVisibleData`).
+
+---
+
+## 📝 Implementation Notes
+
+What landed, and where it diverged from the plan above.
+
+### As planned
+
+- `frontend/src/graph/GraphView.ts` — the interface, verbatim.
+- `frontend/src/graph/graphUtils.ts` — shared `endpointId()`. Chose a new
+  module over `types/graph.ts`, which is types-only and shouldn't carry runtime
+  code. Also did the suggested tidy-up: the five open-coded
+  `typeof x === 'object' ? x.id : x` copies in `GraphRenderer` now go through
+  it, behind a module-level `linkKey()` helper shared by `reconcileGraphData()`,
+  `hasTopologyChanged()`, and `updatePropertiesInPlace()`.
+- `GraphFilters` — one `view: GraphView | null`, `setView()`, no `three` or
+  `3d-force-graph` reference of any kind. `applyHighlightMode()` went from 35
+  lines to 3. `computeFilter()` and the `notifyFilterChange()` ordering are
+  untouched.
+- `GraphRenderer` — `implements GraphView`, gained `setVisibleData()` and
+  `highlight(nodeIds)`, `highlightObjects()` narrowed to `private`. The
+  reference-identity check is centralized in a private `trackVisible()` called
+  from `loadData()`, `updateData()` (all four return paths), and
+  `setVisibleData()`.
+- `main.ts` — collapsed to `graphFilters.setView(view)`, and the `AutoRefresh`
+  callback goes through a `const view: GraphView = graphRenderer` local as the
+  plan suggested.
+
+### Divergences
+
+**1. `tsc --noEmit` was already failing on `main` — 8 pre-existing errors.**
+The plan assumed it was clean. Gating `build` on it meant fixing them first:
+
+- 7 in `GraphRenderer.init()`. Root cause is upstream: `3d-force-graph`'s
+  `ForceGraph3DInstance` is a *circular* type alias
+  (`type X<N,L> = Generic<X<N,L>, N, L>`), so the fluent chain loses its type
+  after the first accessor call and `.nodeRelSize` fails to resolve. Fixed by
+  typing the constructor result as `any` — consistent with the existing
+  `private graph: any` field — and annotating the six callback params. No
+  runtime change. Worth revisiting if upstream fixes the type.
+- 1 in `GuiControls.ts`: the `graphFilters` field was assigned in the
+  constructor and never read — fully dead. Removed the field *and* the
+  constructor param, so `main.ts` now calls
+  `new GuiControls(graphRenderer, autoRefresh)`. This is why the
+  "no changes in `GuiControls.ts`" criterion above is qualified. Unrelated to
+  the refactor itself; it was just the last thing standing between the repo and
+  a clean typecheck.
+
+**2. `GraphRenderer.getGraph()` now has zero callers.** The plan said to keep it
+public for `GuiControls`, but `GuiControls` never used it — `main.ts` was the
+only caller and that line is gone. Left in place rather than widen the diff;
+a candidate for deletion whenever `GraphRenderer` is next touched.
+
+**3. Vitest was added, and the "optional" test work was done up front.** 23
+tests across `GraphFilters.test.ts` (21) and `graphUtils.test.ts` (2), covering
+every case the plan listed plus: no-data, no-match, endpoints already resolved
+to `GraphNode` objects by 3d-force-graph, the empty-term reference-identity
+contract that `setVisibleData()` depends on, and the two named regression paths
+driven through a `FakeGraphView`.
+
+**4. Frontend scripts.** `typecheck` / `test` / `test:watch` added;
+`build` is now `npm run typecheck && vite build`. This also means the Docker
+frontend stage typechecks — `npm ci` installs devDependencies, so `tsc` is
+present. `CLAUDE.md` was updated to match.

--- a/TODO/002a-refactor-GraphFilters.md
+++ b/TODO/002a-refactor-GraphFilters.md
@@ -1,0 +1,248 @@
+# TODO: Refactor `GraphFilters` — Extract a `GraphView` Interface
+
+Carved out of [002-add-mermaid-view.md](./002-add-mermaid-view.md) ("The One
+Real Refactor" / Phase 1).
+
+**Status: ✅ COMPLETE.** Implemented on branch `refactor-GraphFilters`. All
+acceptance criteria met, typecheck + build + tests green, manual smoke test
+passed. See [Implementation Notes](#-implementation-notes) at the bottom for
+what landed differently from this plan.
+
+This refactor stands on its own. It is worth doing whether or not we ever ship
+a 2D view: it removes Three.js from the filter layer, gives the filter logic a
+testable seam, and consolidates two overlapping wiring methods into one.
+
+---
+
+## 🎯 Goal
+
+`GraphFilters` currently owns two things that do not belong together:
+
+1. **Filter semantics** — `computeFilter()`, the documented single source of
+   truth shared by the 3D graph, the jobs table, and the connectors table.
+2. **3D rendering mechanics** — holding a `ForceGraph3D` instance, reading and
+   writing `graph.graphData()`, and walking the Three.js scene graph to find
+   meshes to outline.
+
+Split them. After the refactor `GraphFilters` talks to a narrow `GraphView`
+interface and imports nothing from `three` or `3d-force-graph`.
+
+---
+
+## 📍 Current Coupling — Exactly Where It Lives
+
+All in [frontend/src/graph/GraphFilters.ts](../frontend/src/graph/GraphFilters.ts):
+
+| Line(s) | Coupling |
+| --- | --- |
+| 3 | `import * as THREE from 'three'` |
+| 2 | `import { GraphRenderer }` — concrete class, not an interface |
+| 22–23, 126–132 | Two parallel handles: `graph` (`ForceGraph3D`) *and* `graphRenderer`, set by two separate methods |
+| 147, 153–155 | `filterGraphData()` reads `this.graph.graphData()` and decides whether to reset it |
+| 176 | `applyRemoveMode()` writes `this.graph.graphData({nodes, links})` |
+| 186–189 | `applyHighlightMode()` repeats the same read/compare/reset dance |
+| 201–220 | `applyHighlightMode()` traverses `this.graph.scene()`, tests `child.isMesh` / `child.__graphObjType` / `child.__data`, and hands `THREE.Object3D[]` to `graphRenderer.highlightObjects()` |
+
+The scene traversal at 201–220 is the important one. It re-derives, in
+Three.js terms, a rule `computeFilter()` already expresses in data terms ("a
+link is included when both endpoints are"). That duplicated rule is the actual
+smell — a second view would have to duplicate it a third time.
+
+**Callers today** ([frontend/src/main.ts](../frontend/src/main.ts):36–37) are
+the only place `setGraph()` / `setGraphRenderer()` are used. `SearchBar`,
+`JobsTable`, and `GuiControls` touch only filter-level API
+(`filterGraphData`, `setFilterMode`, `getFilteredLinks`, `getFilteredNodes`,
+`onFilterChange`, `clearFilters`, `getFilterState`) and need no changes.
+
+---
+
+## 🧩 Proposed Interface
+
+New file: `frontend/src/graph/GraphView.ts`
+
+```ts
+import { GraphData } from '../types/graph.js';
+
+/**
+ * The contract a renderer must satisfy to be driven by GraphFilters and
+ * main.ts. Deliberately expressed in graph-data terms (ids, nodes, links) —
+ * no Three.js, no ForceGraph3D, no DOM.
+ */
+export interface GraphView {
+  /** Initial render of the full dataset. */
+  loadData(data: GraphData): void;
+
+  /**
+   * Apply refreshed data. Returns the data the view now holds, which may be
+   * a reconciled object graph rather than `newData` itself (the 3D view
+   * reuses existing node objects to preserve positions).
+   */
+  updateData(newData: GraphData): GraphData;
+
+  /**
+   * Set which subset of the data is rendered. Implementations should skip
+   * the work when handed the same data they are already showing.
+   */
+  setVisibleData(data: GraphData): void;
+
+  /**
+   * Highlight the given nodes, plus every link whose source *and* target are
+   * both in the set. Replaces any previous highlight.
+   */
+  highlight(nodeIds: ReadonlySet<string>): void;
+
+  /** Remove all highlights. */
+  clearHighlights(): void;
+}
+```
+
+### Why `highlight(nodeIds)` and not `highlightObjects(THREE.Object3D[])`
+
+This is the crux of the refactor. `GraphFilters` says *what* is interesting;
+the view decides *how* to make it look interesting. The 3D view keeps its
+scene traversal and `OutlinePass`; a future 2D view adds a CSS class or a
+Cytoscape class. The "both endpoints included" link rule lives in exactly one
+place — inside the implementation, derived from the node-id set it was given.
+
+### Why `setVisibleData()` absorbs the reset-avoidance check
+
+The `currentData.nodes?.length !== originalData.nodes?.length` comparisons at
+lines 153–155 and 186–189 exist to avoid calling `graphData()` needlessly,
+because that restarts the force simulation and visibly jolts the layout. That
+is a 3D-renderer concern and the filter layer should not know about it.
+
+Move it into `GraphRenderer.setVisibleData()` and make the check **reference
+identity** rather than counts:
+
+```ts
+if (data.nodes === this.visibleNodes && data.links === this.visibleLinks) return;
+```
+
+This is strictly safer than the count comparison. `computeFilter()` returns
+the original arrays by reference for an empty search term and freshly built
+arrays from `.filter()` otherwise, so identity distinguishes "nothing changed"
+from "different subset, same size" — which counts alone cannot. Track the refs
+in `loadData()`, `updateData()`, and `setVisibleData()`.
+
+---
+
+## 🔨 Change List
+
+### 1. `frontend/src/graph/GraphView.ts` — new
+
+The interface above. No implementation, no runtime cost.
+
+### 2. `frontend/src/graph/GraphRenderer.ts`
+
+- Declare `export class GraphRenderer implements GraphView`.
+- Add `setVisibleData(data)` — the identity check plus `this.graph.graphData(data)`.
+- Add `highlight(nodeIds: ReadonlySet<string>)` — move the scene traversal
+  from `GraphFilters.applyHighlightMode()` (lines 201–220) here verbatim,
+  ending in the existing `this.highlightObjects(objectsToHighlight)`.
+  The `endpointId()` helper moves too, or is exported from a shared module
+  since both files need it (see step 5).
+- Add a private `visibleNodes` / `visibleLinks` pair, updated by `loadData()`,
+  `updateData()`, and `setVisibleData()`.
+- Narrow `highlightObjects()` to `private` — after this change `GraphFilters`
+  is no longer a caller, and nothing else in the codebase is.
+- Leave everything else alone. `getOutlinePass()`, `updateOutlineSettings()`,
+  `reheat()`, `setDirectionalParticles()`, `updateBackgroundColor()`, and
+  `getGraph()` stay public for `GuiControls`; they are 3D-specific and stay
+  off the `GraphView` interface.
+
+### 3. `frontend/src/graph/GraphFilters.ts`
+
+- Delete the `three` and `GraphRenderer` imports. (`noUnusedLocals` is on in
+  `tsconfig.json`, so a stale import fails the typecheck — good.)
+- Replace the `graph` and `graphRenderer` fields with one `view: GraphView | null`.
+- Replace `setGraph()` and `setGraphRenderer()` with `setView(view: GraphView)`.
+- `setFilterMode()` → `this.view?.clearHighlights()`.
+- `filterGraphData('')` → `this.view.setVisibleData(this.originalData)` then
+  `this.view.clearHighlights()`.
+- `applyRemoveMode()` → `computeFilter()`, then
+  `this.view.setVisibleData({nodes, links})` and `this.view.clearHighlights()`.
+- `applyHighlightMode()` → `this.view.setVisibleData(this.originalData!)` then
+  `this.view.highlight(this.computeFilter(searchTerm).nodeIds)`. The method
+  shrinks from ~35 lines to ~5.
+- `computeFilter()`, `getFilteredLinks()`, `getFilteredNodes()`,
+  `onFilterChange()`, `notifyFilterChange()`, `clearFilters()`, and the
+  `notifyFilterChange()` call ordering are **unchanged**. That is the whole
+  point — the filter semantics are not being touched.
+
+### 4. `frontend/src/main.ts`
+
+- `graphFilters.setGraph(graphRenderer.getGraph()); graphFilters.setGraphRenderer(graphRenderer);`
+  collapses to `graphFilters.setView(graphRenderer);`.
+- Optionally type the local as `const view: GraphView = graphRenderer` and use
+  it in the `AutoRefresh` callback, so the refresh path is view-agnostic too.
+  `GuiControls` still needs the concrete `GraphRenderer` — that is fine and
+  expected until a view toggle exists.
+
+### 5. Shared `endpointId()`
+
+`endpointId()` (`GraphFilters.ts`:16–18) is needed by both files after the
+move. Either export it from `frontend/src/types/graph.ts` (it is a pure
+accessor over `GraphLink`'s `string | GraphNode` endpoints) or put it in a
+small `frontend/src/graph/graphUtils.ts`. `GraphRenderer` already open-codes
+the same `typeof x === 'object' ? x.id : x` pattern in five places
+(`reconcileGraphData`, `hasTopologyChanged`, `updatePropertiesInPlace`), so
+exporting it and using it there is a cheap, in-scope tidy-up.
+
+---
+
+## ✅ Acceptance Criteria
+
+- [x] `GraphFilters.ts` imports nothing from `three` or `3d-force-graph`.
+- [x] `GraphFilters` references no `ForceGraph3D` API (`graphData()`, `scene()`).
+- [x] `GraphRenderer implements GraphView` compiles under `strict`.
+- [x] Behaviour is byte-for-byte equivalent to today for: empty search,
+      Highlight mode, Remove mode, mode switching mid-search, Clear, and
+      auto-refresh with an active search term.
+- [x] No changes required in `SearchBar.ts` or `JobsTable.ts`. **`GuiControls.ts`
+      did change** — see Implementation Notes.
+
+---
+
+## 🧪 Verification
+
+Vitest was added as part of this change (see Implementation Notes), so
+verification is now tests + typecheck + build:
+
+```bash
+cd frontend && npm test && npm run build && cd -
+```
+
+`npm run build` is now `npm run typecheck && vite build`, so it typechecks —
+`npm run typecheck` runs that step alone.
+
+Manual smoke test against a live backend, exercising each acceptance-criteria
+path above. Pay particular attention to two regressions this refactor could
+plausibly introduce:
+
+1. **Layout jolt on every keystroke** — means the `setVisibleData()` identity
+   check is not matching when it should.
+2. **Stale highlights after switching Highlight → Remove → Highlight** — means
+   a `clearHighlights()` call was dropped in the move.
+
+Both were checked manually and both are clean. Both also have unit coverage at
+the filter seam (the tests assert `originalData` is passed *by reference* so
+the identity check can fire, and assert `clearHighlights()` across the
+Highlight → Remove → Highlight sequence). What the tests cannot reach is
+`GraphRenderer` itself — `setVisibleData()`'s identity check against the real
+`graphData()` and the scene traversal in `highlight()` both need WebGL, so the
+manual pass remains the only coverage there.
+
+---
+
+## 📏 Scope
+
+**In:** `GraphView.ts` (new), `GraphRenderer.ts`, `GraphFilters.ts`,
+`main.ts`, and optionally a shared `endpointId()`.
+
+**Out:** any 2D renderer, any view toggle, `GuiControls` genericization,
+backend node-ordering stabilization (that is Phase 0 in
+[002](./002-add-mermaid-view.md) and independent of this work), and any change
+to filter semantics.
+
+Estimate: small/medium. Mostly moving code, one method with real thought in it
+(`setVisibleData`).

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,7 +15,8 @@
         "@types/node": "^24.0.14",
         "@types/three": "^0.178.1",
         "typescript": "^5.8.3",
-        "vite": "^5.0.0"
+        "vite": "^5.0.0",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@babel/runtime": {
@@ -425,6 +426,286 @@
         "node": ">=12"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
+      "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.2.tgz",
+      "integrity": "sha512-l7x215OGvo1s52JWmR8U/DAVzEDWBCIbTm28aeJV/WDTSHgcKXaZTuBT0hJMs5NggilfJTW3clZVvd24yfKJxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.2.tgz",
+      "integrity": "sha512-9u9Xv6c1AJZT0FfwH5vrMG5Jjcwhc1MlyrPu0XfTqkzsmqfks2M6W/o5XwAJgVVN/jHpqqngC1WevHKKTIUtIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.2.tgz",
+      "integrity": "sha512-9W1mbGZAfW3oqd85bhBkmpyHCCzL1TeG/zFFP3vg7b0rlly8cxOcre5nXwz+LHazCwac2MNWgPdPCHndABjpWQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.2.tgz",
+      "integrity": "sha512-0p1lhiCSCyaerFwtrdZQUx7NqGk6LQnaRKWX7tFQqwQgvX0rjM15cIkm3pax1UpEakK14C4mOxx/jSqCBdBRqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.2.tgz",
+      "integrity": "sha512-e+cOJXrJ2L3zx6YzqPg+f6Wbk3V1cKB8bOhbaYdVYN3DdquzNdRAmrbETz1qnt5yp/c7JNlNjmITiA2cVneQ7w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.2.tgz",
+      "integrity": "sha512-JsSMsj6sNat/MuhG5fnBD7QgbtpHKVe30x5/bAVirDHdhoQRXJkF6xc0Jqk8O4fiCUQAzMOoH9wZi3m60c8wtg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.2.tgz",
+      "integrity": "sha512-B5G/zJdHaoJn9vD50eGHWkiWfmq8Uhi3IiLPJTzmZTrAalk1bztUikSXo0qga18ibE0IXboyeMUnhPjhAJ45wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.2.tgz",
+      "integrity": "sha512-6mC/awzKka8W6EoekjegpfGkjz8jXWDX63pqu/HYVpyKtZfu65Jsh4QAH3Kej3CAv/c1oGX7psTmFEbr0mDxLA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.2.tgz",
+      "integrity": "sha512-412MX9fJLdA1IK28EZnc8jYv2HRTleOZgfLQumJ5zy7OeJLZlg/CETwFaXjNmGVxG51cFHpKLqb5LKvBC+HsHA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.2.tgz",
+      "integrity": "sha512-Q/+HI/ToJafZ1iCqGgVQXUEkIjufHCTF0gBQ2a5o3cg7GJ2h0qyq3nvvSmU+bGda2/7ygXpTY4TM6gO9OhQ0ZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.2.tgz",
+      "integrity": "sha512-ZKp/w41n6wCvxzxQHtQSbuphfX3Y4cCvbjkKHusrLx4lh+JWLTU7StSltO/DKARISzbj368d+qUaCjI8K2wzXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.2.tgz",
+      "integrity": "sha512-pxE6xD4KS3eAROkKK5yrhB9/3+vhlhVGMvlQLbdpzrBGDbKrnzx3RLwPaHvasLo6jgaiBLn7e04Df9C4tYhjmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.2.tgz",
+      "integrity": "sha512-4MqEue5re+xIZzAWsB8sj0P1kqZySWqIuN4t6QaIO/YA6SFwySOLruvWQFzfmqk8LBK2P30KCSJwf6mJCZZ5/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.2.tgz",
+      "integrity": "sha512-NweNxxD0Nf9t8v7kodun45Ijp3EIwYY+uydPP6qBEYvfBqhIjN6dZMzlQja3tqX/aLs3F3Uz+AxDpKgRhpOZQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.45.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.45.0.tgz",
@@ -705,10 +986,35 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tweenjs/tween.js": {
       "version": "25.0.0",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
       "integrity": "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -765,6 +1071,92 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@webgpu/types": {
       "version": "0.1.64",
       "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.64.tgz",
@@ -796,6 +1188,33 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -968,6 +1387,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
@@ -1005,6 +1441,44 @@
         "@esbuild/win32-arm64": "0.21.5",
         "@esbuild/win32-ia32": "0.21.5",
         "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/fflate": {
@@ -1064,6 +1538,279 @@
         "node": ">=12"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lil-gui": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/lil-gui/-/lil-gui-0.19.2.tgz",
@@ -1076,6 +1823,16 @@
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "license": "MIT"
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/meshoptimizer": {
       "version": "0.18.1",
       "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
@@ -1084,9 +1841,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -1140,12 +1897,46 @@
       "integrity": "sha512-4EUeAGbB2HWX9njd6bP6tciN6ByJfoaAvmVL9QTaZSeXrW46eNGA9GajiXiPBbvFqxUWFkEbyo6x5qsACUuVfA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/polished": {
       "version": "4.3.1",
@@ -1160,9 +1951,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -1180,7 +1971,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1196,6 +1987,39 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.2.tgz",
+      "integrity": "sha512-opwpo1tQBAcpSUJDt94B7hhLNGOKjCdE//XXjeLrnx9b83bjnw45tXdg1b09yEw/VLFBJGZpwRULMmOZo7ol+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.142.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.2",
+        "@rolldown/binding-darwin-arm64": "1.2.2",
+        "@rolldown/binding-darwin-x64": "1.2.2",
+        "@rolldown/binding-freebsd-x64": "1.2.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.2",
+        "@rolldown/binding-linux-arm64-musl": "1.2.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.2",
+        "@rolldown/binding-linux-x64-gnu": "1.2.2",
+        "@rolldown/binding-linux-x64-musl": "1.2.2",
+        "@rolldown/binding-openharmony-arm64": "1.2.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.2",
+        "@rolldown/binding-win32-x64-msvc": "1.2.2"
       }
     },
     "node_modules/rollup": {
@@ -1238,6 +2062,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1247,6 +2078,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/three": {
       "version": "0.178.0",
@@ -1297,11 +2142,55 @@
         "three": ">=0.168"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/typescript": {
       "version": "5.8.3",
@@ -1382,6 +2271,218 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
+      "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.23",
+        "rolldown": "~1.2.0",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,8 +4,11 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview"
+    "typecheck": "tsc --noEmit",
+    "build": "npm run typecheck && vite build",
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "3d-force-graph": "^1.77.0",
@@ -15,6 +18,7 @@
     "@types/node": "^24.0.14",
     "@types/three": "^0.178.1",
     "typescript": "^5.8.3",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/frontend/src/controls/GuiControls.ts
+++ b/frontend/src/controls/GuiControls.ts
@@ -1,12 +1,10 @@
 import { GUI } from 'lil-gui';
 import { colors } from '../graph/GraphColors.js';
 import { GraphRenderer } from '../graph/GraphRenderer.js';
-import { GraphFilters } from '../graph/GraphFilters.js';
 import { AutoRefresh } from '../utils/autoRefresh.js';
 
 export class GuiControls {
   private graphRenderer: GraphRenderer;
-  private graphFilters: GraphFilters;
   private autoRefresh: AutoRefresh;
   private gui: GUI | null;
   private connectionStatus: 'unknown' | 'connected' | 'error';
@@ -15,9 +13,8 @@ export class GuiControls {
   private lastUpdateController: any;
   private refreshState: any;
 
-  constructor(graphRenderer: GraphRenderer, graphFilters: GraphFilters, autoRefresh: AutoRefresh) {
+  constructor(graphRenderer: GraphRenderer, autoRefresh: AutoRefresh) {
     this.graphRenderer = graphRenderer;
-    this.graphFilters = graphFilters;
     this.autoRefresh = autoRefresh;
     this.gui = null;
     this.connectionStatus = 'unknown';

--- a/frontend/src/graph/GraphFilters.test.ts
+++ b/frontend/src/graph/GraphFilters.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { GraphFilters } from './GraphFilters.js';
+import type { GraphView } from './GraphView.js';
+import { GraphData, GraphLink, GraphNode } from '../types/graph.js';
+
+function node(id: string): GraphNode {
+  return { id };
+}
+
+function link(source: string, target: string, name: string): GraphLink {
+  return {
+    source,
+    target,
+    name,
+    workers: 1,
+    status: 'running',
+    url: `http://teraslice.example.com/jobs/${name}`
+  };
+}
+
+/**
+ * A four-node fixture chosen so the filter cases are distinguishable:
+ *
+ *   kafka:incoming-topicA --job-alpha--> kafka:topicB --job-beta--> es:index-c
+ *   es:orphan  (no links)
+ *
+ * Searching "topic" matches topicA and topicB by id only, so job-alpha is
+ * included purely by the "both endpoints included" bridging rule.
+ */
+function fixture(): GraphData {
+  return {
+    nodes: [
+      node('kafka:incoming-topicA'),
+      node('kafka:topicB'),
+      node('es:index-c'),
+      node('es:orphan')
+    ],
+    links: [
+      link('kafka:incoming-topicA', 'kafka:topicB', 'job-alpha'),
+      link('kafka:topicB', 'es:index-c', 'job-beta')
+    ]
+  };
+}
+
+/** Records what GraphFilters asks of its view, with no renderer involved. */
+class FakeGraphView implements GraphView {
+  public loadedData: GraphData[] = [];
+  public visibleData: GraphData[] = [];
+  public highlighted: ReadonlySet<string>[] = [];
+  public clearHighlightsCount = 0;
+  /** Ordered log of mutating calls, for asserting call sequences. */
+  public calls: string[] = [];
+
+  loadData(data: GraphData): void {
+    this.loadedData.push(data);
+    this.calls.push('loadData');
+  }
+
+  updateData(newData: GraphData): GraphData {
+    this.calls.push('updateData');
+    return newData;
+  }
+
+  setVisibleData(data: GraphData): void {
+    this.visibleData.push(data);
+    this.calls.push('setVisibleData');
+  }
+
+  highlight(nodeIds: ReadonlySet<string>): void {
+    this.highlighted.push(nodeIds);
+    this.calls.push('highlight');
+  }
+
+  clearHighlights(): void {
+    this.clearHighlightsCount++;
+    this.calls.push('clearHighlights');
+  }
+
+  get lastVisible(): GraphData {
+    return this.visibleData[this.visibleData.length - 1];
+  }
+
+  get lastHighlighted(): ReadonlySet<string> {
+    return this.highlighted[this.highlighted.length - 1];
+  }
+}
+
+describe('GraphFilters.computeFilter', () => {
+  let data: GraphData;
+  let filters: GraphFilters;
+
+  beforeEach(() => {
+    data = fixture();
+    filters = new GraphFilters();
+    filters.setOriginalData(data);
+  });
+
+  it('returns an empty result when no data has been set', () => {
+    const empty = new GraphFilters();
+    const result = empty.computeFilter('anything');
+
+    expect(result.nodeIds.size).toBe(0);
+    expect(result.nodes).toEqual([]);
+    expect(result.links).toEqual([]);
+  });
+
+  it('matches everything for an empty search term', () => {
+    const result = filters.computeFilter('');
+
+    expect(result.nodeIds).toEqual(
+      new Set(['kafka:incoming-topicA', 'kafka:topicB', 'es:index-c', 'es:orphan'])
+    );
+    expect(result.nodes).toHaveLength(4);
+    expect(result.links).toHaveLength(2);
+  });
+
+  it('returns the original arrays by reference for an empty search term', () => {
+    // GraphRenderer.setVisibleData() skips a redundant graphData() call by
+    // comparing array identity, so this reference-passing is load-bearing:
+    // break it and the layout jolts on every keystroke.
+    const result = filters.computeFilter('');
+
+    expect(result.nodes).toBe(data.nodes);
+    expect(result.links).toBe(data.links);
+  });
+
+  it('includes a node whose id matches the term', () => {
+    const result = filters.computeFilter('index-c');
+
+    expect(result.nodeIds).toEqual(new Set(['es:index-c']));
+    expect(result.nodes).toEqual([node('es:index-c')]);
+    // job-beta touches es:index-c but its other endpoint is not included.
+    expect(result.links).toEqual([]);
+  });
+
+  it('includes a link whose name matches the term, plus both its endpoints', () => {
+    const result = filters.computeFilter('job-beta');
+
+    expect(result.nodeIds).toEqual(new Set(['kafka:topicB', 'es:index-c']));
+    expect(result.nodes.map(n => n.id)).toEqual(['kafka:topicB', 'es:index-c']);
+    expect(result.links.map(l => l.name)).toEqual(['job-beta']);
+  });
+
+  it('includes a bridging link when both endpoints matched on their own', () => {
+    // "topic" matches only node ids; job-alpha's name does not contain it, but
+    // both of its endpoints are included, so the link comes along.
+    const result = filters.computeFilter('topic');
+
+    expect(result.nodeIds).toEqual(new Set(['kafka:incoming-topicA', 'kafka:topicB']));
+    expect(result.links.map(l => l.name)).toEqual(['job-alpha']);
+  });
+
+  it('matches case-insensitively on both node ids and link names', () => {
+    expect(filters.computeFilter('INDEX-C')).toEqual(filters.computeFilter('index-c'));
+    expect(filters.computeFilter('JOB-ALPHA')).toEqual(filters.computeFilter('job-alpha'));
+  });
+
+  it('resolves endpoints that 3d-force-graph has replaced with node objects', () => {
+    // Once the graph is live, link.source/target are GraphNode objects rather
+    // than id strings. The filter must handle both shapes.
+    const resolved: GraphData = {
+      nodes: data.nodes,
+      links: [{ ...data.links[0], source: data.nodes[0], target: data.nodes[1] }]
+    };
+    filters.setOriginalData(resolved);
+
+    const result = filters.computeFilter('job-alpha');
+
+    expect(result.nodeIds).toEqual(new Set(['kafka:incoming-topicA', 'kafka:topicB']));
+    expect(result.links).toHaveLength(1);
+  });
+
+  it('returns no matches for a term that matches nothing', () => {
+    const result = filters.computeFilter('no-such-thing');
+
+    expect(result.nodeIds.size).toBe(0);
+    expect(result.nodes).toEqual([]);
+    expect(result.links).toEqual([]);
+  });
+
+  it('defaults to the active search term', () => {
+    filters.setView(new FakeGraphView());
+    filters.filterGraphData('job-beta');
+
+    expect(filters.computeFilter().links.map(l => l.name)).toEqual(['job-beta']);
+    expect(filters.getFilteredLinks().map(l => l.name)).toEqual(['job-beta']);
+    expect(filters.getFilteredNodes().map(n => n.id)).toEqual(['kafka:topicB', 'es:index-c']);
+  });
+
+  it('backs the jobs and connectors tables with the same result', () => {
+    expect(filters.getFilteredLinks('topic')).toEqual(filters.computeFilter('topic').links);
+    expect(filters.getFilteredNodes('topic')).toEqual(filters.computeFilter('topic').nodes);
+  });
+});
+
+describe('GraphFilters view interaction', () => {
+  let data: GraphData;
+  let filters: GraphFilters;
+  let view: FakeGraphView;
+
+  beforeEach(() => {
+    data = fixture();
+    view = new FakeGraphView();
+    filters = new GraphFilters();
+    filters.setOriginalData(data);
+    filters.setView(view);
+  });
+
+  it('does nothing when no view is attached', () => {
+    const detached = new GraphFilters();
+    detached.setOriginalData(data);
+
+    expect(() => detached.filterGraphData('topic')).not.toThrow();
+    expect(() => detached.setFilterMode('Remove')).not.toThrow();
+  });
+
+  it('does nothing when no data is set', () => {
+    const empty = new GraphFilters();
+    empty.setView(view);
+    empty.filterGraphData('topic');
+
+    expect(view.calls).toEqual([]);
+  });
+
+  it('restores the full dataset by reference for an empty term', () => {
+    filters.filterGraphData('');
+
+    expect(view.lastVisible).toBe(data);
+    expect(view.clearHighlightsCount).toBe(1);
+  });
+
+  it('keeps all data visible and highlights the match in Highlight mode', () => {
+    filters.setFilterMode('Highlight');
+    view.calls = [];
+    view.clearHighlightsCount = 0;
+
+    filters.filterGraphData('topic');
+
+    // Passing originalData by reference is what lets the view skip a
+    // needless graphData() reset and avoid a layout jolt.
+    expect(view.lastVisible).toBe(data);
+    expect(view.lastHighlighted).toEqual(
+      new Set(['kafka:incoming-topicA', 'kafka:topicB'])
+    );
+    expect(view.calls).toEqual(['setVisibleData', 'highlight']);
+  });
+
+  it('reduces the visible data and clears highlights in Remove mode', () => {
+    filters.setFilterMode('Remove');
+    view.calls = [];
+    view.clearHighlightsCount = 0;
+
+    filters.filterGraphData('topic');
+
+    expect(view.lastVisible.nodes.map(n => n.id)).toEqual([
+      'kafka:incoming-topicA',
+      'kafka:topicB'
+    ]);
+    expect(view.lastVisible.links.map(l => l.name)).toEqual(['job-alpha']);
+    expect(view.clearHighlightsCount).toBe(1);
+    expect(view.highlighted).toEqual([]);
+  });
+
+  it('clears highlights when the mode changes', () => {
+    filters.setFilterMode('Remove');
+
+    expect(view.clearHighlightsCount).toBe(1);
+  });
+
+  it('leaves no stale highlight across Highlight -> Remove -> Highlight', () => {
+    filters.setFilterMode('Highlight');
+    filters.filterGraphData('topic');
+
+    // Switching to Remove must drop the outline from the previous highlight,
+    // and switching back must re-establish it against the full dataset.
+    filters.setFilterMode('Remove');
+    filters.filterGraphData('topic');
+    const clearsAfterRemove = view.clearHighlightsCount;
+
+    filters.setFilterMode('Highlight');
+    filters.filterGraphData('topic');
+
+    expect(clearsAfterRemove).toBeGreaterThan(0);
+    expect(view.calls[view.calls.length - 2]).toBe('setVisibleData');
+    expect(view.calls[view.calls.length - 1]).toBe('highlight');
+    expect(view.lastVisible).toBe(data);
+    expect(view.lastHighlighted).toEqual(
+      new Set(['kafka:incoming-topicA', 'kafka:topicB'])
+    );
+  });
+
+  it('notifies subscribers after applying the filter', () => {
+    const seen: string[] = [];
+    filters.onFilterChange(() => seen.push(filters.getFilterState().searchTerm));
+
+    filters.filterGraphData('topic');
+    filters.filterGraphData('');
+
+    expect(seen).toEqual(['topic', '']);
+  });
+
+  it('clearFilters resets the term and restores the full dataset', () => {
+    filters.filterGraphData('topic');
+    view.calls = [];
+
+    filters.clearFilters();
+
+    expect(filters.getFilterState().searchTerm).toBe('');
+    expect(view.lastVisible).toBe(data);
+    expect(view.calls).toEqual(['setVisibleData', 'clearHighlights']);
+  });
+
+  it('re-applies the active term to refreshed data', () => {
+    filters.setFilterMode('Highlight');
+    filters.filterGraphData('topic');
+
+    // Mirrors the AutoRefresh path in main.ts: new data arrives, the filter is
+    // re-applied against it, and the new term-matched set is highlighted.
+    const refreshed: GraphData = {
+      nodes: [...data.nodes, node('kafka:topicD')],
+      links: [...data.links, link('kafka:topicB', 'kafka:topicD', 'job-gamma')]
+    };
+    filters.setOriginalData(refreshed);
+    filters.filterGraphData(filters.getFilterState().searchTerm);
+
+    expect(view.lastVisible).toBe(refreshed);
+    expect(view.lastHighlighted).toEqual(
+      new Set(['kafka:incoming-topicA', 'kafka:topicB', 'kafka:topicD'])
+    );
+  });
+});

--- a/frontend/src/graph/GraphFilters.ts
+++ b/frontend/src/graph/GraphFilters.ts
@@ -1,6 +1,6 @@
 import { GraphData, GraphNode, GraphLink, FilterState } from '../types/graph.js';
-import { GraphRenderer } from './GraphRenderer.js';
-import * as THREE from 'three';
+import type { GraphView } from './GraphView.js';
+import { endpointId } from './graphUtils.js';
 
 type FilterChangeCallback = () => void;
 
@@ -13,21 +13,15 @@ interface FilterResult {
   links: GraphLink[];
 }
 
-function endpointId(endpoint: string | GraphNode): string {
-  return typeof endpoint === 'object' ? endpoint.id : endpoint;
-}
-
 export class GraphFilters {
   private originalData: GraphData | null;
-  private graph: any; // ForceGraph3D instance
-  private graphRenderer: GraphRenderer | null;
+  private view: GraphView | null;
   private filterState: FilterState;
   private changeCallbacks: FilterChangeCallback[];
 
   constructor() {
     this.originalData = null;
-    this.graph = null;
-    this.graphRenderer = null;
+    this.view = null;
     this.filterState = {
       searchTerm: '',
       filterMode: 'Highlight'
@@ -123,20 +117,18 @@ export class GraphFilters {
     return this.computeFilter(searchTerm).nodes;
   }
 
-  public setGraph(graph: any): void {
-    this.graph = graph;
-  }
-
-  public setGraphRenderer(graphRenderer: GraphRenderer): void {
-    this.graphRenderer = graphRenderer;
+  /**
+   * Attach the view this filter drives. GraphFilters decides *what* is
+   * visible or interesting; the view decides how to render it.
+   */
+  public setView(view: GraphView): void {
+    this.view = view;
   }
 
   public setFilterMode(mode: 'Remove' | 'Highlight'): void {
     this.filterState.filterMode = mode;
     // Clear any existing highlights when switching modes
-    if (this.graphRenderer) {
-      this.graphRenderer.clearHighlights();
-    }
+    this.view?.clearHighlights();
   }
 
   public getFilterState(): FilterState {
@@ -144,19 +136,15 @@ export class GraphFilters {
   }
 
   public filterGraphData(searchTerm: string = ''): void {
-    if (!this.originalData || !this.graph) return;
+    if (!this.originalData || !this.view) return;
 
     this.filterState.searchTerm = searchTerm;
 
     if (!searchTerm) {
-      // Clear all filters; restore original data only if graph was filtered
-      const currentData = this.graph.graphData();
-      if (!currentData || currentData.nodes?.length !== this.originalData.nodes?.length || currentData.links?.length !== this.originalData.links?.length) {
-        this.graph.graphData(this.originalData);
-      }
-      if (this.graphRenderer) {
-        this.graphRenderer.clearHighlights();
-      }
+      // Clear all filters and restore the full dataset. The view is
+      // responsible for skipping the work if it is already showing it.
+      this.view.setVisibleData(this.originalData);
+      this.view.clearHighlights();
       this.notifyFilterChange();
       return;
     }
@@ -173,51 +161,16 @@ export class GraphFilters {
   private applyRemoveMode(searchTerm: string): void {
     const { nodes, links } = this.computeFilter(searchTerm);
 
-    this.graph.graphData({ nodes, links });
+    this.view!.setVisibleData({ nodes, links });
 
     // Clear any highlights in remove mode
-    if (this.graphRenderer) {
-      this.graphRenderer.clearHighlights();
-    }
+    this.view!.clearHighlights();
   }
 
   private applyHighlightMode(searchTerm: string): void {
-    // Keep all original data visible; only re-set graphData if it was previously reduced/filtered
-    const currentData = this.graph.graphData();
-    if (!currentData || currentData.nodes?.length !== this.originalData!.nodes?.length || currentData.links?.length !== this.originalData!.links?.length) {
-      this.graph.graphData(this.originalData!);
-    }
-
-    if (!this.graphRenderer) {
-      console.warn('GraphRenderer not available for highlight mode');
-      return;
-    }
-
-    const { nodeIds } = this.computeFilter(searchTerm);
-
-    // Find the actual 3D objects in the scene to highlight. A node is
-    // highlighted when it is in the filter result; a link is highlighted when
-    // both of its endpoints are, which mirrors computeFilter()'s link rule.
-    const objectsToHighlight: THREE.Object3D[] = [];
-    const scene = this.graph.scene();
-
-    scene.traverse((child: any) => {
-      if (child.isMesh) {
-        if (child.__graphObjType === 'node' && child.__data && nodeIds.has(child.__data.id)) {
-          objectsToHighlight.push(child);
-        } else if (child.__graphObjType === 'link' && child.__data) {
-          const linkData = child.__data;
-          if (linkData.source && linkData.target &&
-              nodeIds.has(endpointId(linkData.source)) &&
-              nodeIds.has(endpointId(linkData.target))) {
-            objectsToHighlight.push(child);
-          }
-        }
-      }
-    });
-
-    console.log(`Highlighting ${objectsToHighlight.length} objects (nodes and links)`);
-    this.graphRenderer.highlightObjects(objectsToHighlight);
+    // Keep all original data visible and let the view highlight the subset.
+    this.view!.setVisibleData(this.originalData!);
+    this.view!.highlight(this.computeFilter(searchTerm).nodeIds);
   }
 
   public clearFilters(): void {

--- a/frontend/src/graph/GraphRenderer.ts
+++ b/frontend/src/graph/GraphRenderer.ts
@@ -2,17 +2,29 @@ import ForceGraph3D from '3d-force-graph';
 import { getNodeColor, getLinkColor, colors } from './GraphColors.js';
 import { OutlinePass } from 'three/examples/jsm/postprocessing/OutlinePass.js';
 import * as THREE from 'three';
-import { GraphData, OutlineSettings } from '../types/graph.js';
+import { GraphData, GraphNode, GraphLink, OutlineSettings } from '../types/graph.js';
+import type { GraphView } from './GraphView.js';
+import { endpointId } from './graphUtils.js';
 import { EdgePopover } from '../controls/EdgePopover.js';
 import { NodePopover } from '../controls/NodePopover.js';
 
-export class GraphRenderer {
+/** Identity of a link across refreshes, used to match old data against new. */
+function linkKey(link: GraphLink): string {
+  return `${endpointId(link.source)}_${endpointId(link.target)}_${link.job_id || ''}`;
+}
+
+export class GraphRenderer implements GraphView {
   private element: HTMLElement;
   private graph: any; // ForceGraph3D instance
   private outlinePass: OutlinePass | null;
   private edgePopover: EdgePopover;
   private nodePopover: NodePopover;
   private showParticles: boolean = false;
+  // The nodes/links arrays currently handed to graphData(), tracked by
+  // reference so setVisibleData() can skip a redundant graphData() call --
+  // which would restart the force simulation and visibly jolt the layout.
+  private visibleNodes: GraphNode[] | null = null;
+  private visibleLinks: GraphLink[] | null = null;
 
   constructor(element: HTMLElement) {
     this.element = element;
@@ -25,11 +37,16 @@ export class GraphRenderer {
   }
 
   private init(): void {
-    this.graph = new ForceGraph3D(this.element)
+    // 3d-force-graph's ForceGraph3DInstance is a circular type alias, so the
+    // fluent chain below loses its type after the first accessor call. Treat
+    // the instance as untyped, matching the `graph: any` field above.
+    const graph: any = new ForceGraph3D(this.element);
+
+    this.graph = graph
       .nodeColor(getNodeColor)
       .nodeRelSize(6)
       .nodeOpacity(0.95)
-      .linkWidth(link => {
+      .linkWidth((link: GraphLink) => {
         // scaled = ((original - min) / (max - min)) * (newMax - newMin) + newMin
         const newSize = ((link.workers - 1) / (200 - 1)) * (20 - 1) + 1;
         return newSize;
@@ -38,20 +55,20 @@ export class GraphRenderer {
       .linkOpacity(0.75)
       .linkDirectionalParticles(0)
       .linkDirectionalParticleWidth(2.5)
-      .linkDirectionalParticleSpeed(link => link.status === 'running' ? 0.005 : 0.002)
-      .onLinkHover(link => {
+      .linkDirectionalParticleSpeed((link: GraphLink) => link.status === 'running' ? 0.005 : 0.002)
+      .onLinkHover((link: GraphLink | null) => {
         if (link) {
           this.edgePopover.show(link);
         } else {
           this.edgePopover.hide(250);
         }
       })
-      .onLinkClick(link => {
+      .onLinkClick((link: GraphLink | null) => {
         if (link) {
           this.edgePopover.show(link);
         }
       })
-      .onNodeHover(node => {
+      .onNodeHover((node: GraphNode | null) => {
         if (node) {
           const links = this.graph.graphData()?.links || [];
           this.nodePopover.show(node, links);
@@ -59,7 +76,7 @@ export class GraphRenderer {
           this.nodePopover.hide(250);
         }
       })
-      .onNodeClick(node => {
+      .onNodeClick((node: GraphNode | null) => {
         if (node) {
           const links = this.graph.graphData()?.links || [];
           this.nodePopover.show(node, links);
@@ -125,6 +142,29 @@ export class GraphRenderer {
 
   public loadData(data: GraphData): void {
     this.graph.graphData(data);
+    this.trackVisible(data);
+  }
+
+  /**
+   * Render the given subset of the data. Skipped entirely when the view is
+   * already showing these exact arrays, because calling graphData() restarts
+   * the force simulation and visibly jolts the layout.
+   *
+   * The check is reference identity rather than a count comparison:
+   * GraphFilters.computeFilter() returns the original arrays by reference for
+   * an empty search term and freshly built arrays otherwise, so identity
+   * distinguishes "nothing changed" from "different subset, same size".
+   */
+  public setVisibleData(data: GraphData): void {
+    if (data.nodes === this.visibleNodes && data.links === this.visibleLinks) return;
+
+    this.graph.graphData(data);
+    this.trackVisible(data);
+  }
+
+  private trackVisible(data: GraphData): void {
+    this.visibleNodes = data.nodes;
+    this.visibleLinks = data.links;
   }
 
   private copyLinkProperties(existingLink: any, newLink: any): void {
@@ -164,17 +204,11 @@ export class GraphRenderer {
 
     const existingLinkMap = new Map<string, any>();
     currentData.links.forEach((link: any) => {
-      const srcId = typeof link.source === 'object' ? link.source.id : link.source;
-      const tgtId = typeof link.target === 'object' ? link.target.id : link.target;
-      const key = `${srcId}_${tgtId}_${link.job_id || ''}`;
-      existingLinkMap.set(key, link);
+      existingLinkMap.set(linkKey(link), link);
     });
 
     const reconciledLinks = newData.links.map((newLink: any) => {
-      const srcId = typeof newLink.source === 'object' ? newLink.source.id : newLink.source;
-      const tgtId = typeof newLink.target === 'object' ? newLink.target.id : newLink.target;
-      const key = `${srcId}_${tgtId}_${newLink.job_id || ''}`;
-      const existingLink = existingLinkMap.get(key);
+      const existingLink = existingLinkMap.get(linkKey(newLink));
 
       if (existingLink) {
         this.copyLinkProperties(existingLink, newLink);
@@ -201,15 +235,9 @@ export class GraphRenderer {
       if (!currentNodeIds.has(n.id)) return true;
     }
 
-    const getLinkKey = (l: any) => {
-      const src = typeof l.source === 'object' ? l.source.id : l.source;
-      const tgt = typeof l.target === 'object' ? l.target.id : l.target;
-      return `${src}_${tgt}_${l.job_id || ''}`;
-    };
-
-    const currentLinkKeys = new Set(currentData.links.map(getLinkKey));
+    const currentLinkKeys = new Set(currentData.links.map(linkKey));
     for (const l of newData.links) {
-      if (!currentLinkKeys.has(getLinkKey(l))) return true;
+      if (!currentLinkKeys.has(linkKey(l))) return true;
     }
 
     return false;
@@ -225,16 +253,10 @@ export class GraphRenderer {
       }
     });
 
-    const getLinkKey = (l: any) => {
-      const src = typeof l.source === 'object' ? l.source.id : l.source;
-      const tgt = typeof l.target === 'object' ? l.target.id : l.target;
-      return `${src}_${tgt}_${l.job_id || ''}`;
-    };
-
     const linkMap = new Map<string, any>();
-    currentData.links.forEach((l: any) => linkMap.set(getLinkKey(l), l));
+    currentData.links.forEach((l: any) => linkMap.set(linkKey(l), l));
     newData.links.forEach((newLink: any) => {
-      const existing = linkMap.get(getLinkKey(newLink));
+      const existing = linkMap.get(linkKey(newLink));
       if (existing) {
         this.copyLinkProperties(existing, newLink);
       }
@@ -251,10 +273,12 @@ export class GraphRenderer {
     const currentData = this.graph.graphData();
     if (!currentData || !currentData.nodes || currentData.nodes.length === 0) {
       this.graph.graphData(newData);
+      this.trackVisible(newData);
       return newData;
     }
 
     if (!this.hasDataChanged(currentData, newData)) {
+      this.trackVisible(currentData);
       return currentData;
     }
 
@@ -263,6 +287,7 @@ export class GraphRenderer {
       // Update properties in-place without calling graphData() to prevent force expansion creep.
       this.updatePropertiesInPlace(currentData, newData);
       this.graph.refresh();
+      this.trackVisible(currentData);
       console.log('Graph data properties updated in-place (no layout shift)');
       return currentData;
     } else {
@@ -275,6 +300,7 @@ export class GraphRenderer {
         n.vz = 0;
       });
       this.graph.graphData(reconciled);
+      this.trackVisible(reconciled);
       console.log('Graph topology updated with position reconciliation');
       return reconciled;
     }
@@ -379,7 +405,35 @@ export class GraphRenderer {
     }
   }
 
-  public highlightObjects(objects: THREE.Object3D[]): void {
+  /**
+   * Outline every node in `nodeIds`, plus every link whose source *and*
+   * target are both in the set -- mirroring computeFilter()'s link rule, but
+   * derived here from the node-id set so the rule lives in only one place.
+   */
+  public highlight(nodeIds: ReadonlySet<string>): void {
+    const objectsToHighlight: THREE.Object3D[] = [];
+    const scene = this.graph.scene();
+
+    scene.traverse((child: any) => {
+      if (child.isMesh) {
+        if (child.__graphObjType === 'node' && child.__data && nodeIds.has(child.__data.id)) {
+          objectsToHighlight.push(child);
+        } else if (child.__graphObjType === 'link' && child.__data) {
+          const linkData = child.__data;
+          if (linkData.source && linkData.target &&
+              nodeIds.has(endpointId(linkData.source)) &&
+              nodeIds.has(endpointId(linkData.target))) {
+            objectsToHighlight.push(child);
+          }
+        }
+      }
+    });
+
+    console.log(`Highlighting ${objectsToHighlight.length} objects (nodes and links)`);
+    this.highlightObjects(objectsToHighlight);
+  }
+
+  private highlightObjects(objects: THREE.Object3D[]): void {
     if (!this.outlinePass) {
       console.warn('OutlinePass not initialized');
       return;

--- a/frontend/src/graph/GraphRenderer.ts
+++ b/frontend/src/graph/GraphRenderer.ts
@@ -110,10 +110,6 @@ export class GraphRenderer implements GraphView {
     }
   }
 
-  public getGraph(): any {
-    return this.graph;
-  }
-
   public updateNodeColors(): void {
     this.graph.nodeColor(getNodeColor);
   }

--- a/frontend/src/graph/GraphView.ts
+++ b/frontend/src/graph/GraphView.ts
@@ -1,0 +1,33 @@
+import { GraphData } from '../types/graph.js';
+
+/**
+ * The contract a renderer must satisfy to be driven by GraphFilters and
+ * main.ts. Deliberately expressed in graph-data terms (ids, nodes, links) --
+ * no Three.js, no ForceGraph3D, no DOM.
+ */
+export interface GraphView {
+  /** Initial render of the full dataset. */
+  loadData(data: GraphData): void;
+
+  /**
+   * Apply refreshed data. Returns the data the view now holds, which may be
+   * a reconciled object graph rather than `newData` itself (the 3D view
+   * reuses existing node objects to preserve positions).
+   */
+  updateData(newData: GraphData): GraphData;
+
+  /**
+   * Set which subset of the data is rendered. Implementations should skip
+   * the work when handed the same data they are already showing.
+   */
+  setVisibleData(data: GraphData): void;
+
+  /**
+   * Highlight the given nodes, plus every link whose source *and* target are
+   * both in the set. Replaces any previous highlight.
+   */
+  highlight(nodeIds: ReadonlySet<string>): void;
+
+  /** Remove all highlights. */
+  clearHighlights(): void;
+}

--- a/frontend/src/graph/graphUtils.test.ts
+++ b/frontend/src/graph/graphUtils.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { endpointId } from './graphUtils.js';
+
+describe('endpointId', () => {
+  it('returns a string endpoint unchanged', () => {
+    expect(endpointId('kafka:topicA')).toBe('kafka:topicA');
+  });
+
+  it('reads the id off a resolved node object', () => {
+    expect(endpointId({ id: 'kafka:topicA', connector_type: 'KAFKA' })).toBe('kafka:topicA');
+  });
+});

--- a/frontend/src/graph/graphUtils.ts
+++ b/frontend/src/graph/graphUtils.ts
@@ -1,0 +1,13 @@
+import { GraphNode } from '../types/graph.js';
+
+/**
+ * Resolve a link endpoint to its node id.
+ *
+ * Links arrive from the API with `source`/`target` as id strings, but
+ * 3d-force-graph replaces them with the resolved GraphNode objects once the
+ * data is loaded. Callers that only need the id should go through here rather
+ * than open-coding the check.
+ */
+export function endpointId(endpoint: string | GraphNode): string {
+  return typeof endpoint === 'object' ? endpoint.id : endpoint;
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,5 +1,6 @@
 import { GraphRenderer } from './graph/GraphRenderer.js';
 import { GraphFilters } from './graph/GraphFilters.js';
+import type { GraphView } from './graph/GraphView.js';
 import { GuiControls } from './controls/GuiControls.js';
 import { SearchBar } from './controls/SearchBar.js';
 import { JobsTable } from './controls/JobsTable.js';
@@ -31,14 +32,15 @@ async function initializeApp(): Promise<void> {
   // Initialize core components
   const graphRenderer = new GraphRenderer(elem);
   const graphFilters = new GraphFilters();
-  
-  // Connect filters to graph
-  graphFilters.setGraph(graphRenderer.getGraph());
-  graphFilters.setGraphRenderer(graphRenderer);
-  
+
+  // Connect filters to the graph via the narrow GraphView contract. GuiControls
+  // still needs the concrete GraphRenderer for its 3D-specific settings.
+  const view: GraphView = graphRenderer;
+  graphFilters.setView(view);
+
   // Initialize auto-refresh
   const autoRefresh = new AutoRefresh((newData) => {
-    const reconciledData = graphRenderer.updateData(newData);
+    const reconciledData = view.updateData(newData);
     graphFilters.setOriginalData(reconciledData);
     // Re-apply the active filter to the refreshed data so the graph and
     // jobs table stay in sync with the current search term.
@@ -46,7 +48,7 @@ async function initializeApp(): Promise<void> {
   });
 
   // Initialize GUI controls with auto-refresh
-  new GuiControls(graphRenderer, graphFilters, autoRefresh);
+  new GuiControls(graphRenderer, autoRefresh);
 
   // Bottom search bar + jobs table drawer
   const jobsTable = new JobsTable(graphFilters);


### PR DESCRIPTION
  Split filter semantics from 3D rendering mechanics. GraphFilters now talks
  to a narrow GraphView interface and imports nothing from three or
  3d-force-graph; the scene traversal and OutlinePass wiring move into
  GraphRenderer.highlight(nodeIds), so the "link included when both endpoints
  are" rule lives only in computeFilter().

  GraphRenderer.setVisibleData() absorbs the reset-avoidance check, now keyed
  on array reference identity rather than node/link counts, which correctly
  distinguishes "nothing changed" from "different subset, same size".

  Also:
  - Add Vitest with 23 tests covering computeFilter() and the view seam.
  - Gate `npm run build` on `tsc --noEmit` via a new `typecheck` script, and fix the 8 pre-existing type errors that exposed: untyped ForceGraph3D fluent chain (upstream circular type alias) and a dead graphFilters field on GuiControls.
  - Share endpointId() via graph/graphUtils.ts, replacing five open-coded copies in GraphRenderer.

  Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>